### PR TITLE
added support for ox_lib logger in backwards compatible fashion

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,6 @@
 Config = {}
+Config.OxLoggingEnable = false -- See https://overextended.github.io/docs/ox_lib/Logger/Server
+Config.DiscordLoggingEnable = true
 Config.MaxWidth = 5.0
 Config.MaxHeight = 5.0
 Config.MaxLength = 5.0

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
-Config.OxLoggingEnable = false -- See https://overextended.github.io/docs/ox_lib/Logger/Server
-Config.DiscordLoggingEnable = true
+Config.EnableOxLogging = false -- See https://overextended.github.io/docs/ox_lib/Logger/Server
+Config.EnableDiscordLogging = true
 Config.MaxWidth = 5.0
 Config.MaxHeight = 5.0
 Config.MaxLength = 5.0

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,6 +5,7 @@ description 'QB-SmallResources'
 version '1.1.0'
 
 shared_script 'config.lua'
+shared_script '@ox_lib/init.lua'
 server_script 'server/*.lua'
 client_script 'client/*.lua'
 

--- a/server/logs.lua
+++ b/server/logs.lua
@@ -68,7 +68,7 @@ exports("OxLog", OxLog)
 ---@param message string the message attached to the log
 ---@param color? Colors what color the message should be
 ---@param tagEveryone? boolean Whether an @everyone tag should be applied to this log.
-local function CreateDiscordLog(name, title, message, color, tagEveryone)
+local function DiscordLog(name, title, message, color, tagEveryone)
     local tag = tagEveryone or false
     local webHook = Webhooks[name] or Webhooks['default']
     local embedData = {
@@ -102,7 +102,7 @@ local function CreateLog(name, title, color, message, tagEveryone)
     end
 
     if Config.EnableDiscordLogging then
-        CreateDiscordLog(name, title, message, color, tagEveryone)
+        DiscordLog(name, title, message, color, tagEveryone)
     end
 end
 

--- a/server/logs.lua
+++ b/server/logs.lua
@@ -90,17 +90,13 @@ local function CreateLog(name, title, color, message, tagEveryone)
                 },
             }
         }
-        PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', embeds = embedData}), { ['Content-Type'] = 'application/json' })
-        Citizen.Wait(100)
-        if tag then
-            PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', content = '@everyone'}), { ['Content-Type'] = 'application/json' })
-        end
+        PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', content = tag and '@everyone' or nil, embeds = embedData }), { ['Content-Type'] = 'application/json' })
     end
 end
 
 exports("CreateLog", CreateLog)
 
----@deprecated use CreateLog instead for discord logging, or OxLog for other logging.
+---@deprecated use the CreateLog export instead for discord logging, or OxLog for other logging.
 RegisterNetEvent('qb-log:server:CreateLog', CreateLog)
 
 QBCore.Commands.Add('testwebhook', 'Test Your Discord Webhook For Logs (God Only)', {}, false, function()

--- a/server/logs.lua
+++ b/server/logs.lua
@@ -54,21 +54,24 @@ local Colors = { -- https://www.spycolor.com/
     ["lightgreen"] = 65309,
 }
 
---- Logs using ox_lib logger regardless of Config.OxLoggingEnable value
+---Logs using ox_lib logger regardless of Config.OxLoggingEnable value
 ---@see https://overextended.github.io/docs/ox_lib/Logger/Server
-RegisterNetEvent('qb-log:server:CreateOxLog', function(source, event, message, ...)
+local function OxLog(source, event, message, ...)
     lib.logger(source, event, message, ...)
-end)
+end
+
+exports("OxLog", OxLog)
 
 ---Creates a log using either ox_lib logger, discord webhooks, or both depending on config. If not needing discord logs, use qb-log:server:CreateOxLog event instead.
 ---@param name string source of the log. Usually a playerId or name of a script.
 ---@param title string the action or 'event' being logged. Usually a verb describing what the name is doing. Example: SpawnVehicle
 ---@param color Colors used for discord logging only, what color the message should be
 ---@param message string the message attached to the log
----@param tagEveryone boolean used for discord logging only. Whether an @everyone tag should be applied to this log.
-RegisterNetEvent('qb-log:server:CreateLog', function(name, title, color, message, tagEveryone)
+---@param tagEveryone? boolean used for discord logging only. Whether an @everyone tag should be applied to this log.
+local function CreateLog(name, title, color, message, tagEveryone)
+    print("create log: " .. name .. title ..color .. message)
     if Config.OxLoggingEnable then
-        lib.logger(name, title, message)
+        OxLog(name, title, message)
     end
 
     if Config.DiscordLoggingEnable then
@@ -94,8 +97,13 @@ RegisterNetEvent('qb-log:server:CreateLog', function(name, title, color, message
             PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', content = '@everyone'}), { ['Content-Type'] = 'application/json' })
         end
     end
-end)
+end
+
+exports("CreateLog", CreateLog)
+
+---@deprecated use CreateLog instead for discord logging, or OxLog for other logging.
+RegisterNetEvent('qb-log:server:CreateLog', CreateLog)
 
 QBCore.Commands.Add('testwebhook', 'Test Your Discord Webhook For Logs (God Only)', {}, false, function()
-    TriggerEvent('qb-log:server:CreateLog', 'testwebhook', 'Test Webhook', 'default', 'Webhook setup successfully')
+    CreateLog('testwebhook', 'Test Webhook', 'default', 'Webhook setup successfully')
 end, 'god')

--- a/server/logs.lua
+++ b/server/logs.lua
@@ -69,7 +69,6 @@ exports("OxLog", OxLog)
 ---@param message string the message attached to the log
 ---@param tagEveryone? boolean used for discord logging only. Whether an @everyone tag should be applied to this log.
 local function CreateLog(name, title, color, message, tagEveryone)
-    print("create log: " .. name .. title ..color .. message)
     if Config.OxLoggingEnable then
         OxLog(name, title, message)
     end


### PR DESCRIPTION
**Describe Pull request**
- Added support for ox_lib logger in the existing 'qb-log:server:CreateLog' event. This can be enabled via config and is designed so that the existing log calls around the code base will work with just a config flag switch
- Added config value to turn off discord logging
- Added new exported function to bypass all config values and just log using ox_lib logger. This is just a simple wrapper pass through, but it's useful to put ox calls behind a wrapper so that we have control over the API and documentation layer and can choose when to introduce breaking changes in the future independent of ox_lib.
- Deprecated logging using events. Made the logging exported functions instead.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]