### PR TITLE
chore(qbx-smallresources/readme): remove taking hostage feature in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Base scripts for QB-Core Framework :building_construction:
 - Useable binoculars
 - Weapon draw animations (normal/holster)
 - Ability to add teleport markers (from a place to another place)
-- Taking hostage
 - Pointing animation with finger (by pressing "B")
 - Seatbelt and cruise control
 - Useable parachute


### PR DESCRIPTION
## Description
The Readme attached to this repo states there is a Take hostage script available within there, but its not available.

I tracked why this was the case and here is why - https://github.com/qbcore-framework/qb-smallresources/issues/11

I propose we remove this advertised feature from readme and declare a statement of work to implement a take hostage script into this repo.

I have a modified version of this script that is cleaner but not optimized that I can bring forth to work from: https://github.com/rubbertoe98/FiveM-Scripts/tree/master/CarryPeople


## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality

I am not really proposing functionality change so I cannot check off this box

- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
