### PR TITLE
feat(entityCreating): Only load if clients can spawn networked entities

### DIFF
--- a/server/entities.lua
+++ b/server/entities.lua
@@ -1,3 +1,7 @@
+local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
+
+if bucketLockDownMode ~= 'inactive' then return end
+
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn
 AddEventHandler('entityCreating', function(handle)

--- a/server/entities.lua
+++ b/server/entities.lua
@@ -1,6 +1,7 @@
 local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
 
-if bucketLockDownMode ~= 'inactive' then return end
+-- If you want to blacklist peds and vehicles from certaiin locations utilize Car gens ymaps as done in streams/car_gen_disablers, as entityCreating handler is very expensive compared to ymap.
+if bucketLockDownMode == 'inactive' then return end
 
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn


### PR DESCRIPTION
## Description

Makes it so the eventhandler only works when we want to check if the clients are spawning networked entities.

## Checklist


- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
