### PR TITLE
fix(car wash): Coordinates and labels missing from config

### DIFF
--- a/client/carwash.lua
+++ b/client/carwash.lua
@@ -73,7 +73,7 @@ end)
 
 CreateThread(function()
     for k in pairs(Config.CarWash.locations) do
-        local carWash = AddBlipForCoord(Config.CarWash.locations[k].coords.x, Config.CarWash.locations[k].coords.y, Config.CarWash.locations[k].coords.z)
+        local carWash = AddBlipForCoord(Config.CarWash.locations[k].x, Config.CarWash.locations[k].y, Config.CarWash.locations[k].z)
         SetBlipSprite (carWash, 100)
         SetBlipDisplay(carWash, 4)
         SetBlipScale  (carWash, 0.75)

--- a/client/carwash.lua
+++ b/client/carwash.lua
@@ -80,7 +80,7 @@ CreateThread(function()
         SetBlipAsShortRange(carWash, true)
         SetBlipColour(carWash, 37)
         BeginTextCommandSetBlipName('STRING')
-        AddTextComponentSubstringPlayerName(Config.CarWash.locations[k].label)
+        AddTextComponentSubstringPlayerName('Car Wash')
         EndTextCommandSetBlipName(carWash)
     end
 end)


### PR DESCRIPTION
PR #31 refactored the config and carwash loop resulting in an error on startup. Additionally the label was removed from config without refactoring the blip. Was #31 even tested?

Fixes #32 

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
