### PR TITLE
fix(ignorelist): Update GetClosestPed() for disabling weapon drops

### DIFF
--- a/client/ignore.lua
+++ b/client/ignore.lua
@@ -12,7 +12,7 @@ end)
 
 AddEventHandler('populationPedCreating', function(x, y, z)
 	Wait(500)	-- Give the entity some time to be created
-	local _, handle = GetClosestPed(x, y, z, 1.0) -- Get the entity handle
+	local handle = GetClosestPed(vec3(x, y, z)) -- Get the entity handle
 	SetPedDropsWeaponsWhenDead(handle, false)
 end)
 


### PR DESCRIPTION
## Description

Changes in core broke this function. The argument and return value order has changed, swapping the position of entity ID and distance values.

@Manason - in regards to backwards compatibility, maybe instead of this fix the function should be reverted to the original order? But then it's weird.. because GetClosestPed() should return a ped - not a distance first.

## Issue

![image](https://github.com/Qbox-project/qbx-smallresources/assets/58707473/c1be675b-0a76-41c7-8a7a-55e13845ddbf)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
