### PR TITLE
Update binoculars.lua

### DIFF
--- a/client/binoculars.lua
+++ b/client/binoculars.lua
@@ -49,7 +49,7 @@ local function handleZoom(cam)
     end
 end
 
-local function HideHUDThisFrame()
+local function hideHUDThisFrame()
     HideHelpTextThisFrame()
     HideHudAndRadarThisFrame()
     HideHudComponentThisFrame(1) -- Wanted Stars
@@ -111,7 +111,7 @@ RegisterNetEvent('binoculars:Toggle', function()
         local zoomvalue = (1.0 / (fov_max-fov_min)) * (fov-fov_min)
         checkInputRotation(cam, zoomvalue)
         handleZoom(cam)
-        HideHUDThisFrame()
+        hideHUDThisFrame()
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
         Wait(0)
     end

--- a/client/binoculars.lua
+++ b/client/binoculars.lua
@@ -49,6 +49,25 @@ local function handleZoom(cam)
     end
 end
 
+local function HideHUDThisFrame()
+    HideHelpTextThisFrame()
+    HideHudAndRadarThisFrame()
+    HideHudComponentThisFrame(1) -- Wanted Stars
+    HideHudComponentThisFrame(2) -- Weapon icon
+    HideHudComponentThisFrame(3) -- Cash
+    HideHudComponentThisFrame(4) -- MP CASH
+    HideHudComponentThisFrame(6)
+    HideHudComponentThisFrame(7)
+    HideHudComponentThisFrame(8)
+    HideHudComponentThisFrame(9)
+    HideHudComponentThisFrame(13) -- Cash Change
+    HideHudComponentThisFrame(11) -- Floating Help Text
+    HideHudComponentThisFrame(12) -- more floating help text
+    HideHudComponentThisFrame(15) -- Subtitle Text
+    HideHudComponentThisFrame(18) -- Game Stream
+    HideHudComponentThisFrame(19) -- weapon wheel
+end
+
 --EVENTS--
 
 -- Activate binoculars
@@ -92,6 +111,7 @@ RegisterNetEvent('binoculars:Toggle', function()
         local zoomvalue = (1.0 / (fov_max-fov_min)) * (fov-fov_min)
         checkInputRotation(cam, zoomvalue)
         handleZoom(cam)
+        HideHUDThisFrame()
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
         Wait(0)
     end


### PR DESCRIPTION
## Description

Hud hiding function readded to hide minimap and other common HUD components when using the binoculars. Not sure if this is the best way to do it, brought it over from the original qb-smallresources binoculars.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [~] I have personally loaded this code into an updated Qbox project and checked all of its functionality. (did this on my mixed qbcore/qbox server.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
