### PR TITLE
Update tackle.lua

### DIFF
--- a/client/tackle.lua
+++ b/client/tackle.lua
@@ -5,7 +5,7 @@ lib.addKeybind({
     onReleased = function(self)
         if cache.vehicle then return end
  	if QBX.PlayerData.metadata.ishandcuffed then return end
-        if IsPedSprinting(cache.ped) or IsPedRunning(cache.ped) then
+	if IsPedSprinting(cache.ped) or IsPedRunning(cache.ped) then
             local coords = GetEntityCoords(cache.ped)
             local targetId, targetPed, _ = lib.getClosestPlayer(coords, 1.6, false)
             if not targetPed then return end

--- a/client/tackle.lua
+++ b/client/tackle.lua
@@ -4,27 +4,27 @@ lib.addKeybind({
     defaultKey = 'E',
     onReleased = function(self)
         if cache.vehicle then return end
-        if QBX.PlayerData.metadata.ishandcuffed then return end
-        if IsPedSprinting(cache.ped) or IsPedRunning(cache.ped) then
-            local coords = GetEntityCoords(cache.ped)
+        if QBXore.Functions.GetPlayerData().metadata["ishandcuffed"] and not IsPedRagdoll(PlayerPedId()) then return end   
+        if IsPedSprinting(PlayerPedId()) or IsPedRunning(PlayerPedId()) then
+            local coords = GetEntityCoords(PlayerPedId())
             local targetId, targetPed, _ = lib.getClosestPlayer(coords, 1.6, false)
             if not targetPed then return end
             if IsPedInAnyVehicle(targetPed, true) then return end
             self:disable(true)
             TriggerServerEvent('tackle:server:TacklePlayer', GetPlayerServerId(targetId))
             lib.requestAnimDict('swimming@first_person@diving')
-            TaskPlayAnim(cache.ped, 'swimming@first_person@diving', 'dive_run_fwd_-45_loop', 3.0, 3.0, -1, 49, 0, false, false, false)
+            TaskPlayAnim(PlayerPedId(), 'swimming@first_person@diving', 'dive_run_fwd_-45_loop', 3.0, 3.0, -1, 49, 0, false, false, false)
             Wait(250)
-            ClearPedTasks(cache.ped)
-            SetPedToRagdoll(cache.ped, 150, 150, 0, 0, 0, 0)
+            ClearPedTasks(PlayerPedId())
+            SetPedToRagdoll(PlayerPedId(), 150, 150, 0, 0, 0, 0)
             RemoveAnimDict('swimming@first_person@diving')
+            SetTimeout(1000, function ()
+                self:disable(false)
+            end)
         end
-        SetTimeout(10000, function ()
-            self:disable(false)
-        end)
     end
 })
 
 RegisterNetEvent('tackle:client:GetTackled', function()
-	SetPedToRagdoll(cache.ped, 7000, 7000, 0, 0, 0, 0)
+	SetPedToRagdoll(PlayerPedId(), 7000, 7000, 0, 0, 0, 0)
 end)

--- a/client/tackle.lua
+++ b/client/tackle.lua
@@ -4,9 +4,9 @@ lib.addKeybind({
     defaultKey = 'E',
     onReleased = function(self)
         if cache.vehicle then return end
-        if QBXore.Functions.GetPlayerData().metadata["ishandcuffed"] and not IsPedRagdoll(PlayerPedId()) then return end   
-        if IsPedSprinting(PlayerPedId()) or IsPedRunning(PlayerPedId()) then
-            local coords = GetEntityCoords(PlayerPedId())
+ if QBX.PlayerData.metadata.ishandcuffed then return end
+        if IsPedSprinting(cache.ped) or IsPedRunning(cache.ped) then
+            local coords = GetEntityCoords(cache.ped)
             local targetId, targetPed, _ = lib.getClosestPlayer(coords, 1.6, false)
             if not targetPed then return end
             if IsPedInAnyVehicle(targetPed, true) then return end

--- a/client/tackle.lua
+++ b/client/tackle.lua
@@ -4,7 +4,7 @@ lib.addKeybind({
     defaultKey = 'E',
     onReleased = function(self)
         if cache.vehicle then return end
- if QBX.PlayerData.metadata.ishandcuffed then return end
+ 	if QBX.PlayerData.metadata.ishandcuffed then return end
         if IsPedSprinting(cache.ped) or IsPedRunning(cache.ped) then
             local coords = GetEntityCoords(cache.ped)
             local targetId, targetPed, _ = lib.getClosestPlayer(coords, 1.6, false)
@@ -13,10 +13,10 @@ lib.addKeybind({
             self:disable(true)
             TriggerServerEvent('tackle:server:TacklePlayer', GetPlayerServerId(targetId))
             lib.requestAnimDict('swimming@first_person@diving')
-            TaskPlayAnim(PlayerPedId(), 'swimming@first_person@diving', 'dive_run_fwd_-45_loop', 3.0, 3.0, -1, 49, 0, false, false, false)
+            TaskPlayAnim(cache.ped, 'swimming@first_person@diving', 'dive_run_fwd_-45_loop', 3.0, 3.0, -1, 49, 0, false, false, false)
             Wait(250)
-            ClearPedTasks(PlayerPedId())
-            SetPedToRagdoll(PlayerPedId(), 150, 150, 0, 0, 0, 0)
+            ClearPedTasks(cache.ped)
+            SetPedToRagdoll(cache.ped, 150, 150, 0, 0, 0, 0)
             RemoveAnimDict('swimming@first_person@diving')
             SetTimeout(1000, function ()
                 self:disable(false)
@@ -26,5 +26,5 @@ lib.addKeybind({
 })
 
 RegisterNetEvent('tackle:client:GetTackled', function()
-	SetPedToRagdoll(PlayerPedId(), 7000, 7000, 0, 0, 0, 0)
+	SetPedToRagdoll(cache.ped, 7000, 7000, 0, 0, 0, 0)
 end)


### PR DESCRIPTION
## Description

This was done by Snipe in the QBox Discord, thank you dude!

Moved:

 SetTimeout(1000, function ()
                self:disable(false) 

To make it stop the tackle function. When outside it was running multiple threads as many times as the tackle key was pressed. Moving it inside should stop the ability of people to tackle before the timeout ran out if this was set higher to something like 10000 or 30000.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
