### PR TITLE
fix: remove id command

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2,12 +2,6 @@ RegisterNetEvent('tackle:server:TacklePlayer', function(playerId)
     TriggerClientEvent('tackle:client:GetTackled', playerId)
 end)
 
-lib.addCommand('id', {
-    help = 'Check Your ID #',
-}, function(source)
-    TriggerClientEvent('QBCore:Notify', source,  'ID: '..source)
-end)
-
 exports.qbx_core:CreateUseableItem('harness', function(source, item)
     TriggerClientEvent('seatbelt:client:UseHarness', source, item)
 end)


### PR DESCRIPTION
## Description

Remove the ID Command in favor of having it in qbx_scoreboard

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
