### PR TITLE
refactor(consumables): callback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "Lua.diagnostics.globals": [
+        "cache",
+        "lib",
+        "QBX"
+    ]
+}

--- a/client/consumables.lua
+++ b/client/consumables.lua
@@ -13,18 +13,18 @@ local function healOxy()
     local count = 9
     while count > 0 do
         Wait(1000)
-        count -= 1
+        count = count - 1
         SetEntityHealth(cache.ped, GetEntityHealth(cache.ped) + 6)
     end
     healing = false
 end
 
 local function trevorEffect()
-    AnimpostfxPlay('DrugsTrevorClownsFightIn', 3.0, 0)
+    AnimpostfxPlay('DrugsTrevorClownsFightIn', 3.0, false)
     Wait(3000)
-    AnimpostfxPlay('DrugsTrevorClownsFight', 3.0, 0)
+    AnimpostfxPlay('DrugsTrevorClownsFight', 3.0, false)
     Wait(3000)
-	AnimpostfxPlay('DrugsTrevorClownsFightOut', 3.0, 0)
+	AnimpostfxPlay('DrugsTrevorClownsFightOut', 3.0, false)
 	AnimpostfxStop('DrugsTrevorClownsFight')
 	AnimpostfxStop('DrugsTrevorClownsFightIn')
 	AnimpostfxStop('DrugsTrevorClownsFightOut')
@@ -52,7 +52,7 @@ local function ecstasyEffect()
     SetFlash(0, 0, 500, 7000, 500)
     while startStamina > 0 do
         Wait(1000)
-        startStamina -= 1
+        startStamina = startStamina - 1
         RestorePlayerStamina(cache.playerId, 1.0)
         if math.random(1, 100) < 51 then
             SetFlash(0, 0, 500, 7000, 500)
@@ -65,11 +65,11 @@ local function ecstasyEffect()
 end
 
 local function alienEffect()
-    AnimpostfxPlay('DrugsMichaelAliensFightIn', 3.0, 0)
+    AnimpostfxPlay('DrugsMichaelAliensFightIn', 3.0, false)
     Wait(math.random(5000, 8000))
-    AnimpostfxPlay('DrugsMichaelAliensFight', 3.0, 0)
+    AnimpostfxPlay('DrugsMichaelAliensFight', 3.0, false)
     Wait(math.random(5000, 8000))
-    AnimpostfxPlay('DrugsMichaelAliensFightOut', 3.0, 0)
+    AnimpostfxPlay('DrugsMichaelAliensFightOut', 3.0, false)
     AnimpostfxStop('DrugsMichaelAliensFightIn')
     AnimpostfxStop('DrugsMichaelAliensFight')
     AnimpostfxStop('DrugsMichaelAliensFightOut')
@@ -84,7 +84,7 @@ local function crackBaggyEffect()
         if math.random(1, 100) < 10 then
             RestorePlayerStamina(cache.playerId, 1.0)
         end
-        startStamina -= 1
+        startStamina = startStamina - 1
         if math.random(1, 100) < 60 and IsPedRunning(cache.ped) then
             SetPedToRagdoll(cache.ped, math.random(1000, 2000), math.random(1000, 2000), 3, false, false, false)
         end
@@ -107,7 +107,7 @@ local function cokeBaggyEffect()
         if math.random(1, 100) < 20 then
             RestorePlayerStamina(cache.playerId, 1.0)
         end
-        startStamina -= 1
+        startStamina = startStamina - 1
         if math.random(1, 100) < 10 and IsPedRunning(cache.ped) then
             SetPedToRagdoll(cache.ped, math.random(1000, 3000), math.random(1000, 3000), 3, false, false, false)
         end
@@ -127,7 +127,7 @@ local function smokeWeed()
         while smokingWeed do
             Wait(10000)
             TriggerServerEvent('hud:server:RelieveStress', math.random(15, 18))
-            relieveCount += 1
+            relieveCount = relieveCount + 1
             if relieveCount == 6 then
                 exports.scully_emotemenu:cancelEmote()
                 if smokingWeed then
@@ -142,7 +142,6 @@ end
 -- Events
 
 RegisterNetEvent('consumables:client:Eat', function(itemName)
-    exports.scully_emotemenu:playEmoteByCommand('eat')
     if lib.progressBar({
         duration = 5000,
         label = 'Eating...',
@@ -153,17 +152,32 @@ RegisterNetEvent('consumables:client:Eat', function(itemName)
             car = false,
             mouse = false,
             combat = true
+        },
+        anim = {
+            clip = 'mp_player_int_eat_burger',
+            dict = 'mp_player_inteat@burger',
+            flag = 49
+        },
+        prop = {
+            {
+                model = 'prop_cs_burger_01',
+                bone = 18905,
+                pos = {x = 0.13, y = 0.05, z = 0.02},
+                rot = {x = -50.0, y = 16.0, z = 60.0}
+            }
         }
     }) then -- if completed
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()[itemName], 'remove')
-        exports.scully_emotemenu:cancelEmote()
+        local used = lib.callback.await('consumables:server:usedItem', false, itemName)
+        if not used then return end
+
         TriggerServerEvent('consumables:server:addHunger', QBX.PlayerData.metadata.hunger + ConsumablesEat[itemName])
         TriggerServerEvent('hud:server:RelieveStress', math.random(2, 4))
+    else -- if canceled
+        exports.qbx_core:Notify('Canceled...', 'error')
     end
 end)
 
 RegisterNetEvent('consumables:client:Drink', function(itemName)
-    exports.scully_emotemenu:playEmoteByCommand('drink')
     if lib.progressBar({
         duration = 5000,
         label = 'Drinking...',
@@ -174,16 +188,31 @@ RegisterNetEvent('consumables:client:Drink', function(itemName)
             car = false,
             mouse = false,
             combat = true
+        },
+        anim = {
+            clip = 'loop_bottle',
+            dict = 'mp_player_intdrink',
+            flag = 49
+        },
+        prop = {
+            {
+                model = 'prop_ld_flow_bottle',
+                bone = 18905,
+                pos = {x = 0.12, y = 0.008, z = 0.03},
+                rot = {x = 240.0, y = -60.0, z = 0.0}
+            }
         }
     }) then -- if completed
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()[itemName], 'remove')
-        exports.scully_emotemenu:cancelEmote()
+        local used = lib.callback.await('consumables:server:usedItem', false, itemName)
+        if not used then return end
+
         TriggerServerEvent('consumables:server:addThirst', QBX.PlayerData.metadata.thirst + ConsumablesDrink[itemName])
+    else -- if canceled
+        exports.qbx_core:Notify('Canceled...', 'error')
     end
 end)
 
 RegisterNetEvent('consumables:client:DrinkAlcohol', function(itemName)
-    exports.scully_emotemenu:playEmoteByCommand('beer7')
     if lib.progressBar({
         duration = math.random(3000, 6000),
         label = 'Drinking liquor...',
@@ -194,21 +223,33 @@ RegisterNetEvent('consumables:client:DrinkAlcohol', function(itemName)
             car = false,
             mouse = false,
             combat = true
+        },
+        anim = {
+            clip = 'loop_bottle',
+            dict = 'mp_player_intdrink',
+            flag = 49
+        },
+        prop = {
+            {
+                model = 'prop_amb_beer_bottle',
+                bone = 18905,
+                pos = {x = 0.12, y = 0.008, z = 0.03},
+                rot = {x = 240.0, y = -60.0, z = 0.0}
+            }
         }
     }) then -- if completed
-        exports.scully_emotemenu:cancelEmote()
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()[itemName], 'remove')
-        TriggerServerEvent('consumables:server:drinkAlcohol', itemName)
-        TriggerServerEvent('consumables:server:addThirst', QBX.PlayerData.metadata.thirst + ConsumablesAlcohol[itemName])
+        local used = lib.callback.await('consumables:server:usedItem', false, itemName)
+        if not used then return end
+
+        TriggerServerEvent('consumables:server:addThirst', {name = itemName,amount = QBX.PlayerData.metadata.thirst + ConsumablesAlcohol[itemName]})
         TriggerServerEvent('hud:server:RelieveStress', math.random(2, 4))
-        alcoholCount += 1
+        alcoholCount = alcoholCount + 1
         if alcoholCount > 1 and alcoholCount < 4 then
             TriggerEvent('evidence:client:SetStatus', 'alcohol', 200)
         elseif alcoholCount >= 4 then
             TriggerEvent('evidence:client:SetStatus', 'heavyalcohol', 200)
         end
     else -- if canceled
-        exports.scully_emotemenu:cancelEmote()
         exports.qbx_core:Notify('Canceled...', 'error')
     end
 end)
@@ -231,8 +272,9 @@ RegisterNetEvent('consumables:client:Cokebaggy', function()
             flag = 49
         }
     }) then -- if completed
-        TriggerServerEvent('consumables:server:useCokeBaggy')
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()['cokebaggy'], 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'cokebaggy')
+        if not used then return end
+
         TriggerEvent('evidence:client:SetStatus', 'widepupils', 200)
         cokeBaggyEffect()
     else -- if canceled
@@ -258,8 +300,9 @@ RegisterNetEvent('consumables:client:Crackbaggy', function()
             flag = 49
         }
     }) then -- if completed
-        TriggerServerEvent('consumables:server:useCrackBaggy')
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()['crack_baggy'], 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'crack_baggy')
+        if not used then return end
+
         TriggerEvent('evidence:client:SetStatus', 'widepupils', 300)
         crackBaggyEffect()
     else -- if canceled
@@ -285,8 +328,9 @@ RegisterNetEvent('consumables:client:EcstasyBaggy', function()
             flag = 49
         }
     }) then -- if completed
-        TriggerServerEvent('consumables:server:useXTCBaggy')
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items().xtcbaggy, 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'xtcbaggy')
+        if not used then return end
+
         ecstasyEffect()
     else -- if canceled
         exports.qbx_core:Notify('Canceled...', 'error')
@@ -311,8 +355,9 @@ RegisterNetEvent('consumables:client:oxy', function()
             flag = 49
         }
     }) then -- if completed
-        TriggerServerEvent('consumables:server:useOxy')
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()['oxy'], 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'oxy')
+        if not used then return end
+
         ClearPedBloodDamage(cache.ped)
 		healOxy()
     else -- if canceled
@@ -338,8 +383,9 @@ RegisterNetEvent('consumables:client:meth', function()
             flag = 49
         }
     }) then -- if completed
-        TriggerServerEvent('consumables:server:useMeth')
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()['meth'], 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'meth')
+        if not used then return end
+
         TriggerEvent('evidence:client:SetStatus', 'widepupils', 300)
 		TriggerEvent('evidence:client:SetStatus', 'agitated', 300)
         methBagEffect()
@@ -361,11 +407,15 @@ RegisterNetEvent('consumables:client:UseJoint', function()
             combat = true
         }
     }) then -- if completed
-        TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()['joint'], 'remove')
+        local used = lib.callback.await('consumables:server:usedItem', false, 'joint')
+        if not used then return end
+
         exports.scully_emotemenu:playEmoteByCommand('joint')
         TriggerEvent('evidence:client:SetStatus', 'weedsmell', 300)
         smokeWeed()
-    end
+    else -- if canceled
+        exports.qbx_core:Notify('Canceled...', 'error')
+	end
 end)
 
 --Threads
@@ -375,7 +425,7 @@ CreateThread(function()
         Wait(10)
         if alcoholCount > 0 then
             Wait(1000 * 60 * 15)
-            alcoholCount -= 1
+            alcoholCount = alcoholCount - 1
         else
             Wait(2000)
         end

--- a/client/consumables.lua
+++ b/client/consumables.lua
@@ -13,7 +13,7 @@ local function healOxy()
     local count = 9
     while count > 0 do
         Wait(1000)
-        count = count - 1
+        count -= 1
         SetEntityHealth(cache.ped, GetEntityHealth(cache.ped) + 6)
     end
     healing = false
@@ -39,7 +39,7 @@ local function methBagEffect()
         if math.random(5, 100) < 10 then
             RestorePlayerStamina(cache.playerId, 1.0)
         end
-        startStamina = startStamina - 1
+        startStamina -= 1
         if math.random(5, 100) < 51 then
             trevorEffect()
         end
@@ -52,7 +52,7 @@ local function ecstasyEffect()
     SetFlash(0, 0, 500, 7000, 500)
     while startStamina > 0 do
         Wait(1000)
-        startStamina = startStamina - 1
+        startStamina -= 1
         RestorePlayerStamina(cache.playerId, 1.0)
         if math.random(1, 100) < 51 then
             SetFlash(0, 0, 500, 7000, 500)
@@ -84,7 +84,7 @@ local function crackBaggyEffect()
         if math.random(1, 100) < 10 then
             RestorePlayerStamina(cache.playerId, 1.0)
         end
-        startStamina = startStamina - 1
+        startStamina -= 1
         if math.random(1, 100) < 60 and IsPedRunning(cache.ped) then
             SetPedToRagdoll(cache.ped, math.random(1000, 2000), math.random(1000, 2000), 3, false, false, false)
         end
@@ -107,7 +107,7 @@ local function cokeBaggyEffect()
         if math.random(1, 100) < 20 then
             RestorePlayerStamina(cache.playerId, 1.0)
         end
-        startStamina = startStamina - 1
+        startStamina -= 1
         if math.random(1, 100) < 10 and IsPedRunning(cache.ped) then
             SetPedToRagdoll(cache.ped, math.random(1000, 3000), math.random(1000, 3000), 3, false, false, false)
         end
@@ -127,7 +127,7 @@ local function smokeWeed()
         while smokingWeed do
             Wait(10000)
             TriggerServerEvent('hud:server:RelieveStress', math.random(15, 18))
-            relieveCount = relieveCount + 1
+            relieveCount += 1
             if relieveCount == 6 then
                 exports.scully_emotemenu:cancelEmote()
                 if smokingWeed then
@@ -241,9 +241,9 @@ RegisterNetEvent('consumables:client:DrinkAlcohol', function(itemName)
         local used = lib.callback.await('consumables:server:usedItem', false, itemName)
         if not used then return end
 
-        TriggerServerEvent('consumables:server:addThirst', {name = itemName,amount = QBX.PlayerData.metadata.thirst + ConsumablesAlcohol[itemName]})
+        TriggerServerEvent('consumables:server:addThirst', {name = itemName, amount = QBX.PlayerData.metadata.thirst + ConsumablesAlcohol[itemName]})
         TriggerServerEvent('hud:server:RelieveStress', math.random(2, 4))
-        alcoholCount = alcoholCount + 1
+        alcoholCount += 1
         if alcoholCount > 1 and alcoholCount < 4 then
             TriggerEvent('evidence:client:SetStatus', 'alcohol', 200)
         elseif alcoholCount >= 4 then
@@ -425,7 +425,7 @@ CreateThread(function()
         Wait(10)
         if alcoholCount > 0 then
             Wait(1000 * 60 * 15)
-            alcoholCount = alcoholCount - 1
+            alcoholCount -= 1
         else
             Wait(2000)
         end

--- a/client/consumables.lua
+++ b/client/consumables.lua
@@ -170,7 +170,7 @@ RegisterNetEvent('consumables:client:Eat', function(itemName)
         local used = lib.callback.await('consumables:server:usedItem', false, itemName)
         if not used then return end
 
-        TriggerServerEvent('consumables:server:addHunger', QBX.PlayerData.metadata.hunger + ConsumablesEat[itemName])
+        lib.callback('consumables:server:addSustenance', false, false, 'hunger', ConsumablesEat[itemName])
         TriggerServerEvent('hud:server:RelieveStress', math.random(2, 4))
     else -- if canceled
         exports.qbx_core:Notify('Canceled...', 'error')
@@ -206,7 +206,7 @@ RegisterNetEvent('consumables:client:Drink', function(itemName)
         local used = lib.callback.await('consumables:server:usedItem', false, itemName)
         if not used then return end
 
-        TriggerServerEvent('consumables:server:addThirst', QBX.PlayerData.metadata.thirst + ConsumablesDrink[itemName])
+        lib.callback('consumables:server:addSustenance', false, false, 'thirst', ConsumablesDrink[itemName])
     else -- if canceled
         exports.qbx_core:Notify('Canceled...', 'error')
     end

--- a/server/consumables.lua
+++ b/server/consumables.lua
@@ -57,25 +57,19 @@ exports.qbx_core:CreateUseableItem('advancedlockpick', function(source)
     TriggerEvent('lockpicks:UseLockpick', source, true)
 end)
 
-RegisterNetEvent('consumables:server:addThirst', function(amount)
+lib.callback.register('consumables:server:addSustenance', function(source, needType, amount)
     local player = exports.qbx_core:GetPlayer(source)
     if not player then return end
 
-    player.Functions.SetMetaData('thirst', amount)
-    TriggerClientEvent('hud:client:UpdateNeeds', source, player.PlayerData.metadata.hunger, amount)
-end)
+    local sustenance = player.PlayerData.metadata[needType] + amount
+    player.Functions.SetMetaData(needType, sustenance)
 
-RegisterNetEvent('consumables:server:addHunger', function(amount)
-    local player = exports.qbx_core:GetPlayer(source)
-    if not player then return end
-
-    player.Functions.SetMetaData('hunger', amount)
-    TriggerClientEvent('hud:client:UpdateNeeds', source, amount, player.PlayerData.metadata.thirst)
+    TriggerClientEvent('hud:client:UpdateNeeds', source, player.PlayerData.metadata[needType], sustenance)
 end)
 
 lib.callback.register('consumables:server:usedItem', function(source, item)
     local player = exports.qbx_core:GetPlayer(source)
-    if not player or not item then return end
+    if not player then return end
 
     return exports.ox_inventory:RemoveItem(source, item, 1)
 end)

--- a/server/consumables.lua
+++ b/server/consumables.lua
@@ -1,41 +1,27 @@
 ----------- / alcohol
-for cAl in pairs(ConsumablesAlcohol) do
-    exports.qbx_core:CreateUseableItem(cAl, function(source, item)
-        local src = source
-        local player = exports.qbx_core:GetPlayer(src)
-        if player.Functions.RemoveItem(item.name, 1, item.slot) then
-            TriggerClientEvent('consumables:client:DrinkAlcohol', src, item.name)
-        end
+for alcohol in pairs(ConsumablesAlcohol) do
+    exports.qbx_core:CreateUseableItem(alcohol, function(source, item)
+        TriggerClientEvent('consumables:client:DrinkAlcohol', source, item.name)
     end)
 end
 
 ----------- / Non-Alcoholic Drinks
-for cDr in pairs(ConsumablesDrink) do
-    exports.qbx_core:CreateUseableItem(cDr, function(source, item)
-        local src = source
-        local player = exports.qbx_core:GetPlayer(src)
-        if player.Functions.RemoveItem(item.name, 1, item.slot) then
-            TriggerClientEvent('consumables:client:Drink', src, item.name)
-        end
+for drink in pairs(ConsumablesDrink) do
+    exports.qbx_core:CreateUseableItem(drink, function(source, item)
+        TriggerClientEvent('consumables:client:Drink', source, item.name)
     end)
 end
 
 ----------- / Food
-for cEa in pairs(ConsumablesEat) do
-    exports.qbx_core:CreateUseableItem(cEa, function(source, item)
-        local src = source
-        local player = exports.qbx_core:GetPlayer(src)
-        if player.Functions.RemoveItem(item.name, 1, item.slot) then
-            TriggerClientEvent('consumables:client:Eat', src, item.name)
-        end
+for food in pairs(ConsumablesEat) do
+    exports.qbx_core:CreateUseableItem(food, function(source, item)
+        TriggerClientEvent('consumables:client:Eat', source, item.name)
     end)
 end
 
 ----------- / Drug
 
-exports.qbx_core:CreateUseableItem('joint', function(source, item)
-    local player = exports.qbx_core:GetPlayer(source)
-	if not player.Functions.RemoveItem(item.name, 1, item.slot) then return end
+exports.qbx_core:CreateUseableItem('joint', function(source)
     TriggerClientEvent('consumables:client:UseJoint', source)
 end)
 
@@ -47,7 +33,7 @@ exports.qbx_core:CreateUseableItem('crack_baggy', function(source)
     TriggerClientEvent('consumables:client:Crackbaggy', source)
 end)
 
-exports.qbx_core:CreateUseableItem('xtcbaggy', function(source, _)
+exports.qbx_core:CreateUseableItem('xtcbaggy', function(source)
     TriggerClientEvent('consumables:client:EcstasyBaggy', source)
 end)
 
@@ -71,68 +57,8 @@ exports.qbx_core:CreateUseableItem('advancedlockpick', function(source)
     TriggerEvent('lockpicks:UseLockpick', source, true)
 end)
 
-RegisterNetEvent('consumables:server:useMeth', function()
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    player.Functions.RemoveItem('meth', 1)
-end)
-
-RegisterNetEvent('consumables:server:useOxy', function()
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    player.Functions.RemoveItem('oxy', 1)
-end)
-
-RegisterNetEvent('consumables:server:useXTCBaggy', function()
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    player.Functions.RemoveItem('xtcbaggy', 1)
-end)
-
-RegisterNetEvent('consumables:server:useCrackBaggy', function()
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    player.Functions.RemoveItem('crack_baggy', 1)
-end)
-
-RegisterNetEvent('consumables:server:useCokeBaggy', function()
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    player.Functions.RemoveItem('cokebaggy', 1)
-end)
-
-RegisterNetEvent('consumables:server:drinkAlcohol', function(item)
-    local player = exports.qbx_core:GetPlayer(source)
-
-    if not player then return end
-
-    local foundItem = nil
-
-    for k in pairs(ConsumablesAlcohol) do
-        if k == item then
-            foundItem = k
-            break
-        end
-    end
-
-    if not foundItem then return end
-
-    player.Functions.RemoveItem(foundItem, 1)
-end)
-
 RegisterNetEvent('consumables:server:addThirst', function(amount)
     local player = exports.qbx_core:GetPlayer(source)
-
     if not player then return end
 
     player.Functions.SetMetaData('thirst', amount)
@@ -141,9 +67,15 @@ end)
 
 RegisterNetEvent('consumables:server:addHunger', function(amount)
     local player = exports.qbx_core:GetPlayer(source)
-
     if not player then return end
 
     player.Functions.SetMetaData('hunger', amount)
     TriggerClientEvent('hud:client:UpdateNeeds', source, amount, player.PlayerData.metadata.thirst)
+end)
+
+lib.callback.register('consumables:server:usedItem', function(source, item)
+    local player = exports.qbx_core:GetPlayer(source)
+    if not player or not item then return end
+
+    return exports.ox_inventory:RemoveItem(source, item, 1)
 end)


### PR DESCRIPTION
## Description

- Fix improper parameters on some of the natives
- Use ox_lib progressbar anims and props over scully emotes
- Use a callback for item usages instead of individual events

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
