### PR TITLE
refactor: rename addHunger to setHunger

### DIFF
--- a/qbx_consumables/server.lua
+++ b/qbx_consumables/server.lua
@@ -1,46 +1,47 @@
 local config = require 'qbx_consumables.config'
 
---- sets player nutrition level in statebag
---- @param source number
---- @param amount number
+---hotfix: remove when qbx_core issue #457 fixed
+---@param source number
+---@param amount number
+---@param type string
+local function metadataSyncHotfix(source, amount, type)
+    local player = exports.qbx_core:GetPlayer(source)
+    if not player then return end
+
+    player.Functions.SetMetaData(type, amount)
+end
+
+---sets player hunger level in statebag
+---@param source number
+---@param amount number
 local function setHunger(source, amount)
     amount = lib.math.clamp(amount, 0, 100)
     Player(source).state.hunger = amount
 
-    --- hotfix: remove when qbx_core issue #457 fixed
-    local player = exports.qbx_core:GetPlayer(source)
-    if not player then return end
-
-    player.Functions.SetMetaData('hunger', amount)
-    --- hotfix
+    metadataSyncHotfix(source, amount, 'hunger') --- hotfix
 end
 
---- raises player nutrition level in statebag
---- @param source number
---- @param amount number
+---raises player hunger level in statebag
+---@param source number
+---@param amount number
 local function addHunger(source, amount)
     local hunger = Player(source).state.hunger or 0
     setHunger(source, hunger + amount)
 end
 
---- sets player watering level in statebag
---- @param source number
---- @param amount number
+---sets player thirst level in statebag
+---@param source number
+---@param amount number
 local function setThirst(source, amount)
     amount = lib.math.clamp(amount, 0, 100)
     Player(source).state.thirst = amount
 
-    --- hotfix: remove when qbx_core issue #457 fixed
-    local player = exports.qbx_core:GetPlayer(source)
-    if not player then return end
-
-    player.Functions.SetMetaData('thirst', amount)
-    --- hotfix
+    metadataSyncHotfix(source, amount, 'thirst') --- hotfix
 end
 
---- raises player watering level in statebag
---- @param source number
---- @param amount number
+---raises player thirst level in statebag
+---@param source number
+---@param amount number
 local function addThirst(source, amount)
     local thirst = Player(source).state.thirst or 0
     setThirst(source, thirst + amount)
@@ -144,27 +145,33 @@ end)
 
 -- Added for ox_inv until I make a proper qbx bridge
 
---- @deprecated confusing name
+---sets player thirst level
+---@deprecated use setThirst export instead
+---@param amount number new hunger level
 RegisterNetEvent('consumables:server:addThirst', function (amount)
     setThirst(source, amount)
 end)
---- @deprecated confusing name
+
+---sets player hunger level
+---@deprecated use setHunger export instead
+---@param amount number new hunger level
 RegisterNetEvent('consumables:server:addHunger', function (amount)
     setHunger(source, amount)
 end)
 
-RegisterNetEvent('consumables:server:setThirst', function (amount, src)
-    if GetInvokingResource() then
-        setThirst(src, amount)
-    else
-        setThirst(source, amount)
-    end
+---client-side call, sets player thirst level
+---@param amount number
+RegisterNetEvent('consumables:server:setThirst', function (amount)
+    if not GetInvokingResource() then setThirst(source, amount) end
 end)
 
-RegisterNetEvent('consumables:server:setHunger', function (amount, src)
-    if GetInvokingResource() then
-        setHunger(src, amount)
-    else
-        setHunger(source, amount)
-    end
+---client-side call, sets player hunger level
+---@param amount number
+RegisterNetEvent('consumables:server:setHunger', function (amount)
+    if not GetInvokingResource() then setHunger(source, amount) end
 end)
+
+exports('setThirst', setThirst)
+exports('addThirst', addThirst)
+exports('setHunger', setHunger)
+exports('addHunger', addHunger)

--- a/qbx_consumables/server.lua
+++ b/qbx_consumables/server.lua
@@ -160,37 +160,3 @@ end)
 RegisterNetEvent('consumables:server:setHunger', function (amount)
     setHunger(source, amount)
 end)
-
-lib.addCommand('thrist', {
-    params = {
-        {
-            name = 'amount',
-            type = 'number',
-        },
-        {
-            name = 'target',
-            type = 'playerId',
-            optional = true
-        }
-    },
-    restricted = 'group.admin'
-}, function (source, args, raw)
-    setThirst(args.target or source, args.amount)
-end)
-
-lib.addCommand('hunger', {
-    params = {
-        {
-            name = 'amount',
-            type = 'number',
-        },
-        {
-            name = 'target',
-            type = 'playerId',
-            optional = true
-        }
-    },
-    restricted = 'group.admin'
-}, function (source, args, raw)
-    setHunger(args.target or source, args.amount)
-end)

--- a/qbx_consumables/server.lua
+++ b/qbx_consumables/server.lua
@@ -153,10 +153,18 @@ RegisterNetEvent('consumables:server:addHunger', function (amount)
     setHunger(source, amount)
 end)
 
-RegisterNetEvent('consumables:server:setThirst', function (amount)
-    setThirst(source, amount)
+RegisterNetEvent('consumables:server:setThirst', function (amount, src)
+    if GetInvokingResource() then
+        setThirst(src, amount)
+    else
+        setThirst(source, amount)
+    end
 end)
 
-RegisterNetEvent('consumables:server:setHunger', function (amount)
-    setHunger(source, amount)
+RegisterNetEvent('consumables:server:setHunger', function (amount, src)
+    if GetInvokingResource() then
+        setHunger(src, amount)
+    else
+        setHunger(source, amount)
+    end
 end)

--- a/qbx_consumables/server.lua
+++ b/qbx_consumables/server.lua
@@ -71,7 +71,6 @@ for alcohol, params in pairs(config.consumables.alcohol) do
         local sustenance = math.random(params.min, params.max)
         relieveStress(source, params.stressRelief.min, params.stressRelief.max)
 
-        exports.qbx_core:Notify(source, sustenance, "error")
         addThirst(source, sustenance)
     end)
 end
@@ -85,7 +84,6 @@ for drink, params in pairs(config.consumables.drink) do
         local sustenance = math.random(params.min, params.max)
         relieveStress(source, params.stressRelief.min, params.stressRelief.max)
 
-        exports.qbx_core:Notify(source, sustenance, "error")
         addThirst(source, sustenance)
     end)
 end
@@ -99,7 +97,6 @@ for food, params in pairs(config.consumables.food) do
         local sustenance = math.random(params.min, params.max)
         relieveStress(source, params.stressRelief.min, params.stressRelief.max)
 
-        exports.qbx_core:Notify(source, sustenance, "error")
         addHunger(source, sustenance)
     end)
 end

--- a/qbx_flipvehicle/client.lua
+++ b/qbx_flipvehicle/client.lua
@@ -1,7 +1,7 @@
 local config = lib.loadJson('qbx_flipvehicle.config')
 
---- @param vehicle number? id of the vehicle, default closes vehicle
---- @param flipTest boolean? costom fliping task
+---@param vehicle number? id of the vehicle, default closes vehicle
+---@param flipTest boolean? costom fliping task
 local function flipVehicle(vehicle, flipTest)
     if cache.vehicle then return end
     if not vehicle then vehicle = lib.getClosestVehicle(GetEntityCoords(cache.ped), config.maxDistance, false) end

--- a/qbx_noshuff/client.lua
+++ b/qbx_noshuff/client.lua
@@ -1,5 +1,5 @@
---- Disables auto seat switching
---- @param seatIndex number
+---Disables auto seat switching
+---@param seatIndex number
 local function disableAutoShuffle(seatIndex)
     SetPedConfigFlag(cache.ped, 184, true)
 
@@ -10,7 +10,7 @@ end
 
 lib.onCache('seat', disableAutoShuffle)
 
---- Makes the player ped shuffle to the next vehicle seat. 
+---Makes the player ped shuffle to the next vehicle seat. 
 local function shuffleSeat(self)
     self:disable(true)
     if cache.vehicle and cache.seat then


### PR DESCRIPTION
## Description

Many users have reported errors related to consumables. The problem lies in the synchronization of the statebag with the player's metadata in qbx_core. However, I have made a few improvements in smallresurces that may be of value.

The name `addHunger` is confusing when replacing an old value instead of adding a new one to it.
A new function `addHunger` has appeared in PR, whose logic is more in line with its name.

Moreover, a hotfix has been placed in the code for https://github.com/Qbox-project/qbx_core/issues/457.

Debug commands at https://github.com/Qbox-project/qbx_adminmenu/pull/57

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
