### PR TITLE
fix(qbx_vehiclepush/client): Check vehicle class

### DIFF
--- a/qbx_vehiclepush/client.lua
+++ b/qbx_vehiclepush/client.lua
@@ -8,7 +8,7 @@ CreateThread(function()
 
         if vehicle and vehicleCoords and not cache.vehicle then
             local vehicleClass = GetVehicleClass(vehicle)
-            local isValidVehicle = vehicleClass ~= 13 or vehicleClass ~= 14 or vehicleClass ~= 15 or vehicleClass ~= 16
+            local isValidVehicle = vehicleClass ~= 13 and vehicleClass ~= 14 and vehicleClass ~= 15 and vehicleClass ~= 16
 
             if isValidVehicle and IsVehicleSeatFree(vehicle, -1)
                and ((GetVehicleEngineHealth(vehicle) >= 0


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

The "or" operator will return true if any of the conditions are true, if vehicleClass = 14 (boat) it will still return isValidVehicle because it does not equal 13. Using the "and" operator we can check it doesn't match any of these.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
