### PR TITLE
chore(fix): locale - german and danish

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -1,42 +1,42 @@
 {
-   "error": {
-      "canceled": "Abgebrochen..",
-      "cruise_control_disabled": "Tempomat deaktiviert",
-      "cruise_control_unavailable": "Tempomat nicht verfügbar",
-      "deleted_recording": "Aufnahme gelöscht!",
-      "later_aligator": "Bis später, Alligator!",
-      "stress_gain": "Fühle mich gestresster!",
-      "no_vehicle_nearby": "Kein Fahrzeug in der Nähe zum Umkippen.",
-      "is_handcuffed": "Du bist gefesselt.",
-      "is_fastened": "Du trägst einen Sicherheitsgurt."
-   },
-   "success": {
-      "cruise_control_enabled": "Tempomat aktiviert",
-      "started_recording": "Aufnahme gestartet!",
-      "stopped_recording": "Aufnahme gestoppt!",
-      "saved_recording": "Aufnahme gespeichert!",
-      "stress_relief": "Fühle mich entspannter!",
-      "flipped_car": "Fahrzeug erfolgreich umgekippt!"
-   },
-   "progress": {
-      "eating": "Essen..",
-      "drinking": "Trinken..",
-      "drinking_liquor": "Alkohol trinken..",
-      "quick_sniff": "Schneller Schnüffler..",
-      "smoking_crack": "Crack rauchen..",
-      "popping_pills": "Pillen schlucken..",
-      "healing": "Heilung..",
-      "smoking_meth": "Meth rauchen..",
-      "lighting_joint": "Joint anzünden..",
-      "flipping_car": "Fahrzeug umkippen..."
-   },
-   "info": {
-      "minutes": "Minuten",
-      "seconds": "Sekunden..",
-      "shuffleSeat": "Sitz wechseln"
-   },
-   "actions": {
-      "push_vehicle": "Drücke [~g~SHIFT~w~] und [~g~E~w~], um das Fahrzeug zu schieben, bis [~g~SHIFT~w~] losgelassen wird",
-      "toggle_cruise_control": "Tempomat umschalten"
-   }
-}
+    "error": {
+       "canceled": "Annulleret..",
+       "cruise_control_disabled": "Fartpilot deaktiveret",
+       "cruise_control_unavailable": "Fartpilot ikke tilgængelig",
+       "deleted_recording": "Optagelse slettet!",
+       "later_aligator": "Vi ses senere, alligator!",
+       "stress_gain": "Føler mig mere stresset!",
+       "no_vehicle_nearby": "Intet køretøj i nærheden at vælte.",
+       "is_handcuffed": "Du er i håndjern.",
+       "is_fastened": "Du har sikkerhedssele på."
+    },
+    "success": {
+       "cruise_control_enabled": "Fartpilot aktiveret",
+       "started_recording": "Optagelse startet!",
+       "stopped_recording": "Optagelse stoppet!",
+       "saved_recording": "Optagelse gemt!",
+       "stress_relief": "Føler mig mere afslappet!",
+       "flipped_car": "Køretøj væltet med succes!"
+    },
+    "progress": {
+       "eating": "Spiser..",
+       "drinking": "Drikker..",
+       "drinking_liquor": "Drikker alkohol..",
+       "quick_sniff": "Hurtig snif..",
+       "smoking_crack": "Ryger crack..",
+       "popping_pills": "Sluger piller..",
+       "healing": "Helbreder..",
+       "smoking_meth": "Ryger meth..",
+       "lighting_joint": "Tænder joint..",
+       "flipping_car": "Vælter køretøj..."
+    },
+    "info": {
+       "minutes": "Minutter",
+       "seconds": "Sekunder..",
+       "shuffleSeat": "Skift sæde"
+    },
+    "actions": {
+       "push_vehicle": "Tryk [~g~SHIFT~w~] og [~g~E~w~] for at skubbe køretøjet, indtil [~g~SHIFT~w~] slippes",
+       "toggle_cruise_control": "Skift fartpilot"
+    }
+ }

--- a/locales/de.json
+++ b/locales/de.json
@@ -4,7 +4,7 @@
       "cruise_control_disabled": "Tempomat deaktiviert",
       "cruise_control_unavailable": "Tempomat deaktiviert",
       "deleted_recording": "Aufnahme gelöscht!",
-      "later_aligator": "Later aligator!",
+      "later_aligator": "Later Alligator!",
       "stress_gain": "Stress nimmt zu!",
       "no_vehicle_nearby": "Kein Fahrzeug zum Umdrehen in der Nähe.",
       "is_handcuffed": "Du bist gefesselt.",
@@ -22,21 +22,21 @@
       "eating": "Essen..",
       "drinking": "Trinken..",
       "drinking_liquor": "Trinke Alkohol..",
-      "quick_sniff": "Quick sniff..",
-      "smoking_crack": "Smoking crack..",
-      "popping_pills": "Popping pills..",
-      "healing": "Healing..",
-      "smoking_meth": "Smoking meth..",
-      "lighting_joint": "Lighting joint..",
-      "flipping_car": "Flipping Vehicle..."
+      "quick_sniff": "Schnelle Nase..",
+      "smoking_crack": "Crack rauchen..",
+      "popping_pills": "Pillen einwerfen..",
+      "healing": "Heilen..",
+      "smoking_meth": "Meth rauchen..",
+      "lighting_joint": "Joint anzünden..",
+      "flipping_car": "Fahrzeug umdrehen..."
    },
    "info": {
-      "minutes": "minutes",
-      "seconds": "seconds..",
-      "shuffleSeat": "Shuffle seat"
+      "minutes": "Minuten",
+      "seconds": "Sekunden..",
+      "shuffleSeat": "Sitz wechseln"
    },
    "actions": {
-      "push_vehicle": "Press [~g~SHIFT~w~] and [~g~E~w~] to push the vehicle until [~g~SHIFT~w~] release",
-      "toggle_cruise_control": "Toggle Cruise Control"
+      "push_vehicle": "Drücke [~g~SHIFT~w~] und [~g~E~w~], um das Fahrzeug zu schieben, bis [~g~SHIFT~w~] losgelassen wird",
+      "toggle_cruise_control": "Tempomat umschalten"
    }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,42 @@
+{
+   "error": {
+      "canceled": "Abgebrochen..",
+      "cruise_control_disabled": "Tempomat deaktiviert",
+      "cruise_control_unavailable": "Tempomat deaktiviert",
+      "deleted_recording": "Aufnahme gelöscht!",
+      "later_aligator": "Later aligator!",
+      "stress_gain": "Stress nimmt zu!",
+      "no_vehicle_nearby": "Kein Fahrzeug zum Umdrehen in der Nähe.",
+      "is_handcuffed": "Du bist gefesselt.",
+      "is_fastened": "Du trägst einen Sicherheitsgurt."
+   },
+   "success": {
+      "cruise_control_enabled": "Tempomat eingeschaltet",
+      "started_recording": "Aufnahme gestartet!",
+      "stopped_recording": "Auzfnahme gestoppt!",
+      "saved_recording": "Aufnahme gespeichert!",
+      "stress_relief": "Du entspannst dich!",
+      "flipped_car": "Fahrzeug erfolgreich gedreht!"
+   },
+   "progress": {
+      "eating": "Essen..",
+      "drinking": "Trinken..",
+      "drinking_liquor": "Trinke Alkohol..",
+      "quick_sniff": "Quick sniff..",
+      "smoking_crack": "Smoking crack..",
+      "popping_pills": "Popping pills..",
+      "healing": "Healing..",
+      "smoking_meth": "Smoking meth..",
+      "lighting_joint": "Lighting joint..",
+      "flipping_car": "Flipping Vehicle..."
+   },
+   "info": {
+      "minutes": "minutes",
+      "seconds": "seconds..",
+      "shuffleSeat": "Shuffle seat"
+   },
+   "actions": {
+      "push_vehicle": "Press [~g~SHIFT~w~] and [~g~E~w~] to push the vehicle until [~g~SHIFT~w~] release",
+      "toggle_cruise_control": "Toggle Cruise Control"
+   }
+}


### PR DESCRIPTION
## Description

Add correct contents to da.json. - (with ChatGPT because I don't speak danish)
The last commit was wrong. In da.json, de locales where put in and obviously with a translator

Create de.json with correct translations depending on context.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
