### PR TITLE
fix(qbx_hudcomponents): Allow weapon scopes to be used

### DIFF
--- a/qbx_hudcomponents/client.lua
+++ b/qbx_hudcomponents/client.lua
@@ -18,8 +18,10 @@ end)
 
 lib.onCache('weapon', function(weapon)
     if not weapon then return end
+
     CreateThread(function()
         while cache.weapon ~= weapon do Wait(1) end -- Wait for cache.weapon to update
+
         while cache.weapon == weapon do
             if not IsFirstPersonAimCamActive() then
                 HideHudComponentThisFrame(14)

--- a/qbx_hudcomponents/client.lua
+++ b/qbx_hudcomponents/client.lua
@@ -4,18 +4,29 @@ local disableControls = config.disable.controls
 local displayAmmo = config.disable.displayAmmo
 
 CreateThread(function()
-    
     for i = 1, #disableHudComponents do
         SetHudComponentSize(disableHudComponents[i],0.0,0.0)
     end
-    
+
     while true do
         for i = 1, #disableControls do
             DisableControlAction(2, disableControls[i], true)
         end
-        
         Wait(0)
     end
+end)
+
+lib.onCache('weapon', function(weapon)
+    if not weapon then return end
+    CreateThread(function()
+        while cache.weapon ~= weapon do Wait(1) end -- Wait for cache.weapon to update
+        while cache.weapon == weapon do
+            if not IsFirstPersonAimCamActive() then
+                HideHudComponentThisFrame(14)
+            end
+            Wait(0)
+        end
+    end)
 end)
 
 local function addDisableHudComponents(hudComponents)

--- a/qbx_hudcomponents/client.lua
+++ b/qbx_hudcomponents/client.lua
@@ -16,20 +16,22 @@ CreateThread(function()
     end
 end)
 
-lib.onCache('weapon', function(weapon)
-    if not weapon then return end
+if config.disable.recticle then
+    lib.onCache('weapon', function(weapon)
+        if not weapon then return end
 
-    CreateThread(function()
-        while cache.weapon ~= weapon do Wait(1) end -- Wait for cache.weapon to update
+        CreateThread(function()
+            while cache.weapon ~= weapon do Wait(1) end -- Wait for cache.weapon to update
 
-        while cache.weapon == weapon do
-            if not IsFirstPersonAimCamActive() then
-                HideHudComponentThisFrame(14)
+            while cache.weapon == weapon do
+                if not IsFirstPersonAimCamActive() then
+                    HideHudComponentThisFrame(14)
+                end
+                Wait(0)
             end
-            Wait(0)
-        end
+        end)
     end)
-end)
+end
 
 local function addDisableHudComponents(hudComponents)
     local hudComponentsType = type(hudComponents)

--- a/qbx_hudcomponents/config.lua
+++ b/qbx_hudcomponents/config.lua
@@ -1,7 +1,7 @@
 return {
     disable = {
         -- https://docs.fivem.net/natives/?_0x6806C51AD12B83B8
-        hudComponents = {1, 2, 3, 4, 7, 9, 13, 14, 19, 20, 21, 22},
+        hudComponents = {1, 2, 3, 4, 7, 9, 13, 19, 20, 21, 22},
 
         -- https://docs.fivem.net/docs/game-references/controls/
         controls = {37},

--- a/qbx_hudcomponents/config.lua
+++ b/qbx_hudcomponents/config.lua
@@ -5,5 +5,8 @@ return {
 
         -- https://docs.fivem.net/docs/game-references/controls/
         controls = {37},
+
+        -- the small white dot in the middle of the screen when aiming with a weapon.
+        recticle = true,
     }
 }


### PR DESCRIPTION
## Description

Allows weapon scopes to be used by using IsFirstPersonAimCamActive(). Closes https://github.com/Qbox-project/qbx_smallresources/issues/119

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
