### PR TITLE
fix(qbx_entitiesblacklist): Add client-side entity cleanup

### DIFF
--- a/qbx_entitiesblacklist/client.lua
+++ b/qbx_entitiesblacklist/client.lua
@@ -1,4 +1,3 @@
-
 local config = require 'qbx_entitiesblacklist.config'
 
 Citizen.CreateThread(function()

--- a/qbx_entitiesblacklist/client.lua
+++ b/qbx_entitiesblacklist/client.lua
@@ -1,0 +1,27 @@
+
+local config = require 'qbx_entitiesblacklist.config'
+
+Citizen.CreateThread(function()
+    while true do
+        if config.settings.bucketLockDownMode ~= 'inactive' then
+            local playerPed = GetPlayerPed(-1)
+            local vehicles = GetGamePool('CVehicle')
+            for _, vehicle in ipairs(vehicles) do
+                local model = GetEntityModel(vehicle)
+                if config.blacklisted[model] then
+                    DeleteEntity(vehicle)
+                end
+            end
+            local peds = GetGamePool('CPed')
+            for _, ped in ipairs(peds) do
+                if ped ~= playerPed then 
+                    local model = GetEntityModel(ped)
+                    if config.blacklisted[model] then
+                        DeleteEntity(ped)
+                    end
+                end
+            end
+        end
+        Citizen.Wait(config.settings.cleanupInterval)
+    end
+end)

--- a/qbx_entitiesblacklist/config.lua
+++ b/qbx_entitiesblacklist/config.lua
@@ -1,41 +1,53 @@
+-- config.lua
 return {
     blacklisted = {
+        -- Aircraft
         [`SHAMAL`] = true,
         [`LUXOR`] = true,
         [`LUXOR2`] = true,
         [`JET`] = true,
         [`LAZER`] = true,
-        [`BUZZARD`] = true,
-        [`BUZZARD2`] = true,
-        [`ANNIHILATOR`] = true,
-        [`SAVAGE`] = true,
         [`TITAN`] = true,
-        [`RHINO`] = true,
-        [`FIRETRUK`] = true,
-        [`MULE`] = true,
-        [`MAVERICK`] = true,
-        [`BLIMP`] = true,
-        [`AIRTUG`] = true,
-        [`CAMPER`] = true,
         [`HYDRA`] = true,
+        
+        -- Military & Armed Vehicles
+        [`RHINO`] = true,
         [`OPPRESSOR`] = true,
+        [`OPPRESSOR2`] = true,
         [`technical3`] = true,
         [`insurgent3`] = true,
         [`apc`] = true,
         [`tampa3`] = true,
-        [`trailersmall2`] = true,
-        [`halftrack`] = true,
-        [`hunter`] = true,
-        [`vigilante`] = true,
-        [`akula`] = true,
-        [`barrage`] = true,
         [`khanjali`] = true,
+        [`ruiner2`] = true,
+        [`deluxo`] = true,
+        
+        -- Helicopters
+        [`BUZZARD`] = true,
+        [`BUZZARD2`] = true,
+        [`ANNIHILATOR`] = true,
+        [`SAVAGE`] = true,
+        [`MAVERICK`] = true,
+        [`hunter`] = true,
+        [`akula`] = true,
+        
+        -- Special Vehicles
+        [`FIRETRUK`] = true,
+        [`MULE`] = true,
+        [`AIRTUG`] = true,
+        [`CAMPER`] = true,
+        [`vigilante`] = true,
+        [`barrage`] = true,
         [`caracara`] = true,
-        [`blimp3`] = true,
         [`menacer`] = true,
-        [`oppressor2`] = true,
         [`scramjet`] = true,
         [`strikeforce`] = true,
+        
+        -- Blimps
+        [`BLIMP`] = true,
+        [`blimp3`] = true,
+        
+        -- Arena War Vehicles
         [`cerberus`] = true,
         [`cerberus2`] = true,
         [`cerberus3`] = true,
@@ -43,13 +55,22 @@ return {
         [`scarab2`] = true,
         [`scarab3`] = true,
         [`rrocket`] = true,
-        [`ruiner2`] = true,
-        [`deluxo`] = true,
+        [`voltic2`] = true,
+        
+        -- Utility/Trailers
+        [`trailersmall2`] = true,
+        [`halftrack`] = true,
+        
+        -- Law Enforcement Peds
         [`s_m_y_ranger_01`] = true,
         [`s_m_y_sheriff_01`] = true,
         [`s_m_y_cop_01`] = true,
         [`s_f_y_sheriff_01`] = true,
         [`s_f_y_cop_01`] = true,
         [`s_m_y_hwaycop_01`] = true
+    },
+    settings = {
+        cleanupInterval = 100,
+        bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
     }
 }

--- a/qbx_entitiesblacklist/config.lua
+++ b/qbx_entitiesblacklist/config.lua
@@ -1,4 +1,3 @@
--- config.lua
 return {
     blacklisted = {
         -- Aircraft

--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -1,14 +1,11 @@
 local config = require 'qbx_entitiesblacklist.config'
-local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
+if config.settings.bucketLockDownMode == 'inactive' or table.type(config.blacklisted) == 'empty' then 
+    return 
+end
 
--- If you want to blacklist peds and vehicles from certaiin locations utilize Car gens ymaps as done in streams/car_gen_disablers, as entityCreating handler is very expensive compared to ymap.
-if bucketLockDownMode == 'inactive' or table.type(config.blacklisted) == 'empty' then return end
-
--- Blacklisting entities can just be handled entirely server side with onesync events
--- No need to run coroutines to supress or delete these when we can simply delete them before they spawn
 AddEventHandler('entityCreating', function(handle)
     local entityModel = GetEntityModel(handle)
-
+    
     if config.blacklisted[entityModel] then
         CancelEvent()
     end

--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -5,7 +5,6 @@ end
 
 AddEventHandler('entityCreating', function(handle)
     local entityModel = GetEntityModel(handle)
-    
     if config.blacklisted[entityModel] then
         CancelEvent()
     end


### PR DESCRIPTION
Adds client-side cleanup functionality to remove blacklisted entities that might bypass server prevention. Improves security by scanning entity pools for restricted vehicles and peds.

- Implements GetGamePool for efficient entity scanning
- Adds configurable cleanup interval
- Maintains existing server-side prevention
- Reorganized config file with categorized entities

## Description
Implements a client-side cleanup system to enhance security by removing any blacklisted entities that might bypass the server-side prevention. Uses GetGamePool for efficient scanning of vehicles and peds, with a configurable cleanup interval setting in the config file.

## Checklist
<!-- Put an x inside the [ ] to check an item, like so: [x] -->
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.