### PR TITLE
fix(qbxy_entitiesblacklist): Remove Checks & Add console prints

### DIFF
--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -1,15 +1,11 @@
 local config = require 'qbx_entitiesblacklist.config'
-local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
-
--- If you want to blacklist peds and vehicles from certaiin locations utilize Car gens ymaps as done in streams/car_gen_disablers, as entityCreating handler is very expensive compared to ymap.
-if bucketLockDownMode == 'inactive' or table.type(config.blacklisted) == 'empty' then return end
-
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn
 AddEventHandler('entityCreating', function(handle)
     local entityModel = GetEntityModel(handle)
 
     if config.blacklisted[entityModel] then
+        lib.print.warning('[qbx_smallresources] Blocked entity creation for model: ' .. entityModel)
         CancelEvent()
     end
 end)

--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -1,4 +1,7 @@
 local config = require 'qbx_entitiesblacklist.config'
+local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
+-- If you want to blacklist peds and vehicles from certaiin locations utilize Car gens ymaps as done in streams/car_gen_disablers, as entityCreating handler is very expensive compared to ymap.
+if bucketLockDownMode ~= 'inactive' or table.type(config.blacklisted) == 'empty' then return end
 lib.print.warn('[qbx_entitiesblacklist] You have entity blacklist enabled, this means that any entity that is blacklisted in config.lua will not be able to spawn, you can change this in qbx_smallresource/qbx_entitiesblacklist/config.lua')
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn

--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -1,11 +1,16 @@
 local config = require 'qbx_entitiesblacklist.config'
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn
+if type(config.blacklisted) ~= 'table' then
+    lib.print.warning('[qbx_entitiesblacklist] Blacklisted vehicles is not a table')
+    return
+end
+
 AddEventHandler('entityCreating', function(handle)
     local entityModel = GetEntityModel(handle)
 
     if config.blacklisted[entityModel] then
-        lib.print.warning('[qbx_smallresources] Blocked entity creation for model: ' .. entityModel)
+        lib.print.warning('[qbx_entitiesblacklist] Blocked entity creation for model: ' .. entityModel)
         CancelEvent()
     end
 end)

--- a/qbx_entitiesblacklist/server.lua
+++ b/qbx_entitiesblacklist/server.lua
@@ -1,4 +1,5 @@
 local config = require 'qbx_entitiesblacklist.config'
+lib.print.warn('[qbx_entitiesblacklist] You have entity blacklist enabled, this means that any entity that is blacklisted in config.lua will not be able to spawn, you can change this in qbx_smallresource/qbx_entitiesblacklist/config.lua')
 -- Blacklisting entities can just be handled entirely server side with onesync events
 -- No need to run coroutines to supress or delete these when we can simply delete them before they spawn
 if type(config.blacklisted) ~= 'table' then
@@ -10,7 +11,6 @@ AddEventHandler('entityCreating', function(handle)
     local entityModel = GetEntityModel(handle)
 
     if config.blacklisted[entityModel] then
-        lib.print.warning('[qbx_entitiesblacklist] Blocked entity creation for model: ' .. entityModel)
         CancelEvent()
     end
 end)


### PR DESCRIPTION
## Description

This pr is focusing on the entity blacklist, and how currently it is checking for an entitylockdown mode, which as of fivems current state is not in the best shape. 
This pr concludes that instead of adding the check, that most users will not use, instead it will put a warning in server console when a vehicle is deleted, stating what resource deleteded it.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
