### PR TITLE
feat(qbx_vehicleradio): Vehicle radio control

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -8,7 +8,8 @@
        "stress_gain": "Føler mig mere stresset!",
        "no_vehicle_nearby": "Intet køretøj i nærheden at vælte.",
        "is_handcuffed": "Du er i håndjern.",
-       "is_fastened": "Du har sikkerhedssele på."
+       "is_fastened": "Du har sikkerhedssele på.",
+        "vehicle_radio_off": "Køretøjets radio slukket"
     },
     "success": {
        "cruise_control_enabled": "Fartpilot aktiveret",
@@ -16,7 +17,8 @@
        "stopped_recording": "Optagelse stoppet!",
        "saved_recording": "Optagelse gemt!",
        "stress_relief": "Føler mig mere afslappet!",
-       "flipped_car": "Køretøj væltet med succes!"
+       "flipped_car": "Køretøj væltet med succes!",
+       "vehicle_radio_on": "Køretøjets radio tændt"
     },
     "progress": {
        "eating": "Spiser..",

--- a/locales/de.json
+++ b/locales/de.json
@@ -8,7 +8,8 @@
       "stress_gain": "Stress nimmt zu!",
       "no_vehicle_nearby": "Kein Fahrzeug zum Umdrehen in der Nähe.",
       "is_handcuffed": "Du bist gefesselt.",
-      "is_fastened": "Du trägst einen Sicherheitsgurt."
+      "is_fastened": "Du trägst einen Sicherheitsgurt.",
+      "vehicle_radio_off": "Fahrzeugradio ausgeschaltet"
    },
    "success": {
       "cruise_control_enabled": "Tempomat eingeschaltet",
@@ -16,7 +17,8 @@
       "stopped_recording": "Auzfnahme gestoppt!",
       "saved_recording": "Aufnahme gespeichert!",
       "stress_relief": "Du entspannst dich!",
-      "flipped_car": "Fahrzeug erfolgreich gedreht!"
+      "flipped_car": "Fahrzeug erfolgreich gedreht!",
+      "vehicle_radio_on": "Fahrzeugradio eingeschaltet"
    },
    "progress": {
       "eating": "Essen..",

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,7 +8,8 @@
       "stress_gain": "Feeling More Stressed!",
       "no_vehicle_nearby": "No Vehicle Nearby For Flipping.",
       "is_handcuffed": "You are handcuffed.",
-      "is_fastened": "You wear a seat belt."
+      "is_fastened": "You wear a seat belt.",
+      "vehicle_radio_off": "Vehicle Radio Turned Off"
    },
    "success": {
       "cruise_control_enabled": "Cruise control enabled",
@@ -16,7 +17,8 @@
       "stopped_recording": "Stopped Recording!",
       "saved_recording": "Saved Recording!",
       "stress_relief": "Feeling More Relaxed!",
-      "flipped_car": "Vehicle Flipped Successfully!"
+      "flipped_car": "Vehicle Flipped Successfully!",
+      "vehicle_radio_on": "Vehicle Radio Turned On"
    },
    "progress": {
       "eating": "Eating..",

--- a/locales/es.json
+++ b/locales/es.json
@@ -8,7 +8,8 @@
       "stress_gain": "¡Te sientes más estresado!",
       "no_vehicle_nearby": "No hay vehículos cercanos para voltear.",
       "is_handcuffed": "Estás esposado.",
-      "is_fastened": "Llevas puesto el cinturón de seguridad."
+      "is_fastened": "Llevas puesto el cinturón de seguridad.",
+      "vehicle_radio_off": "Radio del vehículo apagada"
    },
    "success": {
       "cruise_control_enabled": "Control de crucero habilitado",
@@ -16,7 +17,8 @@
       "stopped_recording": "¡Grabación detenida!",
       "saved_recording": "¡Grabación guardada!",
       "stress_relief": "¡Te sientes más relajado!",
-      "flipped_car": "¡Vehículo volteado con éxito!"
+      "flipped_car": "¡Vehículo volteado con éxito!",
+      "vehicle_radio_on": "Radio del vehículo encendida"
    },
    "progress": {
       "eating": "Comiendo...",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -8,7 +8,8 @@
       "stress_gain": "Vous vous sentez plus stressé !",
       "no_vehicle_nearby": "Aucun véhicule à proximité pour le retourner.",
       "is_handcuffed": "Vous êtes menotté.",
-      "is_fastened": "Vous portez une ceinture de sécurité."
+      "is_fastened": "Vous portez une ceinture de sécurité.",
+      "vehicle_radio_off": "Radio du véhicule éteinte"
    },
    "success": {
       "cruise_control_enabled": "Régulateur de vitesse activé",
@@ -16,7 +17,8 @@
       "stopped_recording": "Enregistrement arrêté !",
       "saved_recording": "Enregistrement sauvegardé !",
       "stress_relief": "Vous vous sentez plus détendu !",
-      "flipped_car": "Véhicule retourné avec succès !"
+      "flipped_car": "Véhicule retourné avec succès !",
+      "vehicle_radio_on": "Radio du véhicule allumée"
    },
    "progress": {
       "eating": "En train de manger..",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -8,7 +8,8 @@
       "stress_gain": "Je voelt je gestressed!",
       "no_vehicle_nearby": "Geen voertuigen in de buurt.",
       "is_handcuffed": "Je bent gehandboeit.",
-      "is_fastened": "Je draagt je gordel."
+      "is_fastened": "Je draagt je gordel.",
+      "vehicle_radio_off": "Voertuigradio uitgeschakeld"
    },
    "success": {
       "cruise_control_enabled": "Cruise control aangezet",
@@ -16,7 +17,8 @@
       "stopped_recording": "Opname gestopt!",
       "saved_recording": "Opname opgeslagen!",
       "stress_relief": "Je voelt je relaxed!",
-      "flipped_car": "Voertuig geflipped!"
+      "flipped_car": "Voertuig geflipped!",
+      "vehicle_radio_on": "Voertuigradio ingeschakeld"
    },
    "progress": {
       "eating": "Aan het eten..",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -8,7 +8,8 @@
     "stress_gain": "Wzrost poziomu stresu!",
     "no_vehicle_nearby": "W pobliżu nie ma pojazdu do przewrócenia.",
     "is_handcuffed": "Masz założone kajdanki.",
-    "is_fastened": "Masz zapięte pasy."
+    "is_fastened": "Masz zapięte pasy.",
+    "vehicle_radio_off": "Radio w pojeździe wyłączone"
   },
   "success": {
     "cruise_control_enabled": "Tempomat włączony",
@@ -16,7 +17,8 @@
     "stopped_recording": "Zatrzymano nagrywanie!",
     "saved_recording": "Zapisano nagranie!",
     "stress_relief": "Uczucie relaksu!",
-    "flipped_car": "Pojazd został pomyślnie przewrócony!"
+    "flipped_car": "Pojazd został pomyślnie przewrócony!",
+    "vehicle_radio_on": "Radio w pojeździe włączone"
   },
   "progress": {
     "eating": "Jedzenie..",

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -8,7 +8,8 @@
        "stress_gain": "Sentindo-se mais estressado!",
        "no_vehicle_nearby": "Nenhum veículo próximo para virar.",
        "is_handcuffed": "Você está algemado.",
-       "is_fastened": "Você está usando o cinto de segurança."
+       "is_fastened": "Você está usando o cinto de segurança.",
+       "vehicle_radio_off": "Rádio do veículo desligado"
     },
     "success": {
        "cruise_control_enabled": "Controle de cruzeiro ativado",
@@ -16,7 +17,8 @@
        "stopped_recording": "Gravação interrompida!",
        "saved_recording": "Gravação salva!",
        "stress_relief": "Sentindo-se mais relaxado!",
-       "flipped_car": "Veículo virado com sucesso!"
+       "flipped_car": "Veículo virado com sucesso!",
+        "vehicle_radio_on": "Rádio do veículo ligado"
     },
     "progress": {
        "eating": "Comendo..",
@@ -40,4 +42,3 @@
        "toggle_cruise_control": "Alternar Controle de Cruzeiro"
     }
  }
- 

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -8,7 +8,8 @@
       "stress_gain": "A Sentir Mais Stress!",
       "no_vehicle_nearby": "Nenhum veículo nas proximidades para virar.",
       "is_handcuffed": "Estás algemado.",
-      "is_fastened": "Tens o cinto de segurança posto."
+      "is_fastened": "Tens o cinto de segurança posto.",
+      "vehicle_radio_off": "Rádio do veículo desligado"
    },
    "success": {
       "cruise_control_enabled": "Controlo de cruzeiro ativado",
@@ -16,7 +17,8 @@
       "stopped_recording": "Gravação Parada!",
       "saved_recording": "Gravação Guardada!",
       "stress_relief": "A Sentires-te Mais Relaxado!",
-      "flipped_car": "Veículo Virado com Sucesso!"
+      "flipped_car": "Veículo Virado com Sucesso!",
+      "vehicle_radio_on": "Rádio do veículo ligado"
    },
    "progress": {
       "eating": "A Comer..",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -8,7 +8,8 @@
       "stress_gain": "Te simți mai stresat!",
       "no_vehicle_nearby": "Nu există niciun vehicul în apropiere pentru a-l răsturna.",
       "is_handcuffed": "Ești încătușat.",
-      "is_fastened": "Porți centura de siguranță."
+      "is_fastened": "Porți centura de siguranță.",
+      "vehicle_radio_off": "Radio vehicul oprit"
    },
    "success": {
       "cruise_control_enabled": "Pilot automat activat",
@@ -16,7 +17,8 @@
       "stopped_recording": "Înregistrare oprită!",
       "saved_recording": "Înregistrare salvată!",
       "stress_relief": "Te simți mai relaxat!",
-      "flipped_car": "Vehicul răsturnat cu succes!"
+      "flipped_car": "Vehicul răsturnat cu succes!",
+      "vehicle_radio_on": "Radio vehicul pornit"
    },
    "progress": {
       "eating": "Mănânci..",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -8,7 +8,8 @@
       "stress_gain": "Daha stresli hissediyorsun!",
       "no_vehicle_nearby": "Yakında çevrilebilecek bir araç yok.",
       "is_handcuffed": "Kelepçelisin.",
-      "is_fastened": "Emniyet kemeri taktın."
+      "is_fastened": "Emniyet kemeri taktın.",
+      "vehicle_radio_off": "Araç radyosu kapatıldı"
    },
    "success": {
       "cruise_control_enabled": "Hız sabitleyici etkinleştirildi",
@@ -16,7 +17,8 @@
       "stopped_recording": "Kayıt durduruldu!",
       "saved_recording": "Kayıt kaydedildi!",
       "stress_relief": "Daha rahat hissediyorsun!",
-      "flipped_car": "Araç başarıyla çevrildi!"
+      "flipped_car": "Araç başarıyla çevrildi!",
+      "vehicle_radio_on": "Araç radyosu açıldı"
    },
    "progress": {
        "eating": "Yemek yiyorsun..",

--- a/locales/zh-cn.json
+++ b/locales/zh-cn.json
@@ -8,7 +8,8 @@
       "stress_gain": "感到更紧张了!",
       "no_vehicle_nearby": "附近没有车辆可以翻转。",
       "is_handcuffed": "你被铐住了。",
-      "is_fastened": "你系好了安全带。"
+      "is_fastened": "你系好了安全带。",
+      "vehicle_radio_off": "车辆收音机已关闭"
    },
    "success": {
       "cruise_control_enabled": "巡航控制已启用",
@@ -16,7 +17,8 @@
       "stopped_recording": "停止录音!",
       "saved_recording": "录音已保存!",
       "stress_relief": "感到更放松了!",
-      "flipped_car": "车辆翻转成功!"
+      "flipped_car": "车辆翻转成功!",
+      "vehicle_radio_on": "车辆收音机已开启"
    },
    "progress": {
       "eating": "正在吃东西..",

--- a/qbx_vehicleradio/client.lua
+++ b/qbx_vehicleradio/client.lua
@@ -1,22 +1,19 @@
 local config = lib.loadJson('qbx_vehicleradio.config')
 local radioEnabled = not config.disableRadioByDefault
-local isInVehicle = false
 
 RegisterCommand(config.toggleCommand, function()
-    local playerPed = PlayerPedId()
-    local currentVehicle = GetVehiclePedIsIn(playerPed, false)
-
-    if currentVehicle == 0 then
+    local currentVehicle = cache.vehicle
+    if not currentVehicle or currentVehicle == 0 then
         return
     end
 
     radioEnabled = not radioEnabled
 
     if radioEnabled then
-        exports.qbx_core:Notify('Vehicle radio is now ON', 'success')
+        exports.qbx_core:Notify(locale('success.vehicle_radio_on'), 'success')
         SetUserRadioControlEnabled(true)
     else
-        exports.qbx_core:Notify('Vehicle radio is now OFF', 'error')
+        exports.qbx_core:Notify(locale('error.vehicle_radio_off'), 'error')
         SetVehRadioStation(currentVehicle, "OFF")
         SetUserRadioControlEnabled(false)
     end
@@ -26,27 +23,13 @@ if config.toggleKey then
     RegisterKeyMapping(config.toggleCommand, "Toggle Vehicle Radio", "keyboard", config.toggleKey)
 end
 
-Citizen.CreateThread(function()
-    while true do
-        local playerPed = PlayerPedId()
-        local currentVehicle = GetVehiclePedIsIn(playerPed, false)
-
-        if currentVehicle ~= 0 then
-            if not isInVehicle then
-                isInVehicle = true
-                SetUserRadioControlEnabled(radioEnabled)
-                if not radioEnabled then
-                    SetVehRadioStation(currentVehicle, "OFF")
-                end
-            end
-
-            if not radioEnabled and GetPlayerRadioStationName() ~= nil then
-                SetVehRadioStation(currentVehicle, "OFF")
-            end
-        else
-            isInVehicle = false
+lib.onCache('vehicle', function(currentVehicle)
+    if currentVehicle and currentVehicle ~= 0 then
+        SetUserRadioControlEnabled(radioEnabled)
+        if not radioEnabled then
+            SetVehRadioStation(currentVehicle, "OFF")
         end
-
-        Citizen.Wait(500)
+    else
+        SetUserRadioControlEnabled(true)
     end
 end)

--- a/qbx_vehicleradio/client.lua
+++ b/qbx_vehicleradio/client.lua
@@ -1,0 +1,52 @@
+local config = lib.loadJson('qbx_vehicleradio.config')
+local radioEnabled = not config.disableRadioByDefault
+local isInVehicle = false
+
+RegisterCommand(config.toggleCommand, function()
+    local playerPed = PlayerPedId()
+    local currentVehicle = GetVehiclePedIsIn(playerPed, false)
+
+    if currentVehicle == 0 then
+        return
+    end
+
+    radioEnabled = not radioEnabled
+
+    if radioEnabled then
+        exports.qbx_core:Notify('Vehicle radio is now ON', 'success')
+        SetUserRadioControlEnabled(true)
+    else
+        exports.qbx_core:Notify('Vehicle radio is now OFF', 'error')
+        SetVehRadioStation(currentVehicle, "OFF")
+        SetUserRadioControlEnabled(false)
+    end
+end, false)
+
+if config.toggleKey then
+    RegisterKeyMapping(config.toggleCommand, "Toggle Vehicle Radio", "keyboard", config.toggleKey)
+end
+
+Citizen.CreateThread(function()
+    while true do
+        local playerPed = PlayerPedId()
+        local currentVehicle = GetVehiclePedIsIn(playerPed, false)
+
+        if currentVehicle ~= 0 then
+            if not isInVehicle then
+                isInVehicle = true
+                SetUserRadioControlEnabled(radioEnabled)
+                if not radioEnabled then
+                    SetVehRadioStation(currentVehicle, "OFF")
+                end
+            end
+
+            if not radioEnabled and GetPlayerRadioStationName() ~= nil then
+                SetVehRadioStation(currentVehicle, "OFF")
+            end
+        else
+            isInVehicle = false
+        end
+
+        Citizen.Wait(500)
+    end
+end)

--- a/qbx_vehicleradio/config.json
+++ b/qbx_vehicleradio/config.json
@@ -1,0 +1,5 @@
+{
+    "disableRadioByDefault": false,
+    "toggleCommand": "togglevehradio",
+    "toggleKey": "F9"
+}


### PR DESCRIPTION
## Description

Adds a vehicle radio control that allows players to:
- Completely disables vehicle radio
- Maintains disabled state when changing vehicles
- Requires manual toggle to re-enable by command or toggle key

## Checklist

-  [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.