### PR TITLE
Update client.lua

### DIFF
--- a/qbx_ignore/client.lua
+++ b/qbx_ignore/client.lua
@@ -12,6 +12,9 @@ CreateThread(function()
         for _, scgrp in next, config.blacklisted.scenarioGroups do
             SetScenarioGroupEnabled(scgrp, false)
         end
+
+        DistantCopCarSirens(false) --Appears that this needs to be called regularly to keep ambient sirens disabled.
+        
         Wait(10000)
     end
 end)


### PR DESCRIPTION
Disable DistantCopCarSirens within a loop to ensure they don't play ever.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

DistantCopCarSirens can be heard when players have emergency lights activated but no sirens (i.e. with luxart etc).

Calling it only once does not keep these sirens disabled. Added it to the client loop to continually disable DistantCopCarSirens and this seems to have fixed it on our server.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x] My pull request fits the contribution guidelines & code conventions.
