### PR TITLE
feat(client): Disable Player Headshots Config

### DIFF
--- a/qbx_ignore/client.lua
+++ b/qbx_ignore/client.lua
@@ -48,6 +48,12 @@ if config.disable.idleCamera then
     DisableVehiclePassengerIdleCamera(true)
 end
 
+if config.disable.headshots then
+    lib.onCache('ped', function(ped)
+        SetPedSuffersCriticalHits(ped, false)
+    end)
+end
+
 local function pistolWhipLoop()
     CreateThread(function()
         local sleep

--- a/qbx_ignore/config.lua
+++ b/qbx_ignore/config.lua
@@ -3,8 +3,11 @@ return {
         -- Disables the Idle Cinematic Camera
         idleCamera = true,
 
-        -- Disabled distance sirens, distance car alarms, etc
+        -- Disables distance sirens, distance car alarms, etc
         ambience = true,
+
+        -- Disables headshots instantly killing players
+        headshots = false,
 
     },
 


### PR DESCRIPTION
## Description

Adds a config option for server owners to disable headshots auto killing players
*(since its asked 100 times in support channels)*

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
