### PR TITLE
fix(teleports): close menu on zone exit

### DIFF
--- a/qbx_teleports/client.lua
+++ b/qbx_teleports/client.lua
@@ -64,6 +64,9 @@ CreateThread(function()
                 end,
                 onExit = function()
                     currentLevel = {0, 0}
+                    if lib.getOpenMenu() == 'elevator_interact_menu' then
+                        lib.hideMenu(true)
+                    end
                     lib.hideTextUI()
                 end
             })


### PR DESCRIPTION
## Description

This fixes the issue where players could open the elevator menu and then leave the zone and TP from anywhere in the world.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
