### PR TITLE
Get rid of preventing R* Editor with gabz mapdata

### DIFF
--- a/qbx_editor/client.lua
+++ b/qbx_editor/client.lua
@@ -1,17 +1,3 @@
--- We do this check as we don't want players using these commands due to crashing with escrowed maps.
-local shouldAllow, mapNames = true, {
-    'cfx-gabz-mapdata'
-}
-
-for i = 1, #mapNames do
-    local state = GetResourceState(mapNames[i])
-    if state == 'starting' or state == 'started' then
-        shouldAllow = false
-    end
-end
-
-if not shouldAllow then return end
-
 RegisterCommand('record', function()
     StartRecording(1)
     exports.qbx_core:Notify(locale('success.started_recording'), 'success')


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
PR Changes the fact that qbx_editor doesnt work if the gabz mapdata resource is initialised, no longer needed as R* editor works fine with mapdata changes

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
