### PR TITLE
fix(security): harden client-triggered server events

### DIFF
--- a/qbx_consumables/server.lua
+++ b/qbx_consumables/server.lua
@@ -1,4 +1,16 @@
 local config = require 'qbx_consumables.config'
+local removableItems = {
+    joint = true,
+    cokebaggy = true,
+    crack_baggy = true,
+    xtcbaggy = true,
+    oxy = true,
+    meth = true,
+}
+
+local function isFiniteNumber(value)
+    return type(value) == 'number' and value == value and value > -math.huge and value < math.huge
+end
 
 ---hotfix: remove when qbx_core issue #470 fixed https://github.com/Qbox-project/qbx_core/issues/470
 ---Enforces synchronization of player's hunger or thirst metadata with value from statebag
@@ -144,49 +156,52 @@ end)
 
 lib.callback.register('consumables:server:usedItem', function(source, item)
     local player = exports.qbx_core:GetPlayer(source)
-    if not player then return end
+    if not player or not removableItems[item] then return end
 
     return exports.ox_inventory:RemoveItem(source, item, 1)
 end)
 
 ---Set player's hunger state to 'amount'
 ---@param amount number
-RegisterNetEvent('consumables:server:setHunger', function(amount)
-    --Make sure this can only be triggered from the client
-    if not GetInvokingResource() then setHunger(source, amount) end
+AddEventHandler('consumables:server:setHunger', function(amount)
+    if not isFiniteNumber(amount) then return end
+    setHunger(source, amount)
 end)
 
 ---Increment player's hunger state by 'amount'
 ---@param amount number new hunger level
-RegisterNetEvent('consumables:server:addHunger', function(amount)
+AddEventHandler('consumables:server:addHunger', function(amount)
+    if not isFiniteNumber(amount) then return end
+
     local resource = GetInvokingResource()
     --handles calls from ox_inventory's QB bridge, using improper QB nomenclature
     --todo remove upon merger of a proper qbx bridge to ox_inventory
     if resource == 'ox_inventory' then
         setHunger(source, amount)
-    --Make sure this can only be triggered from the client
-    elseif not resource then
+    else
         addHunger(source, amount)
     end
 end)
 
 ---Set player's thirst state to 'amount'
 ---@param amount number
-RegisterNetEvent('consumables:server:setThirst', function(amount)
-    --Make sure this can only be triggered from the client
-    if not GetInvokingResource() then setThirst(source, amount) end
+AddEventHandler('consumables:server:setThirst', function(amount)
+    if not isFiniteNumber(amount) then return end
+    setThirst(source, amount)
 end)
 
 ---Increment player's thirst state by 'amount'
 ---@param amount number new thirst level
-RegisterNetEvent('consumables:server:addThirst', function(amount)
+AddEventHandler('consumables:server:addThirst', function(amount)
+    if not isFiniteNumber(amount) then return end
+
     local resource = GetInvokingResource()
     --handles calls from ox_inventory's QB bridge, using improper QB nomenclature
     --todo remove upon merger of a proper qbx bridge to ox_inventory
     if resource == 'ox_inventory' then
         setThirst(source, amount)
     --Make sure this can only be triggered from the client
-    elseif not resource then
+    else
         addThirst(source, amount)
     end
 end)

--- a/qbx_tackle/server.lua
+++ b/qbx_tackle/server.lua
@@ -1,10 +1,26 @@
+local lastTackle = {}
+
 RegisterNetEvent('tackle:server:TacklePlayer', function(target)
     local src = source
-    
-    local srcCoords = GetEntityCoords(GetPlayerPed(src))
-    local targetCoords = GetEntityCoords(GetPlayerPed(target))
+    if math.type(target) ~= 'integer' or target == src then return end
+
+    local now = GetGameTimer()
+    if lastTackle[src] and now - lastTackle[src] < 1000 then return end
+
+    local srcPed = GetPlayerPed(src)
+    local targetPed = GetPlayerPed(target)
+    if srcPed == 0 or targetPed == 0 then return end
+    if GetVehiclePedIsIn(srcPed, false) ~= 0 or GetVehiclePedIsIn(targetPed, false) ~= 0 then return end
+
+    local srcCoords = GetEntityCoords(srcPed)
+    local targetCoords = GetEntityCoords(targetPed)
 
     if #(srcCoords - targetCoords) > 2.0 then return end
 
+    lastTackle[src] = now
     TriggerClientEvent('tackle:client:GetTackled', target)
+end)
+
+AddEventHandler('playerDropped', function()
+    lastTackle[source] = nil
 end)

--- a/qbx_vehiclepush/server.lua
+++ b/qbx_vehiclepush/server.lua
@@ -1,6 +1,14 @@
 RegisterNetEvent('qbx_vehiclepush:server:push', function(data)
+    if type(data) ~= 'table' or math.type(data.netId) ~= 'integer' then return end
+    if data.direction ~= nil and data.direction ~= 'left' and data.direction ~= 'right' and data.direction ~= 'front' and data.direction ~= 'back' then return end
+
     local vehicle = NetworkGetEntityFromNetworkId(data.netId)
-    if not DoesEntityExist(vehicle) then return end
+    if not DoesEntityExist(vehicle) or GetEntityType(vehicle) ~= 2 then return end
+
+    local ped = GetPlayerPed(source)
+    if ped == 0 or GetVehiclePedIsIn(ped, false) ~= 0 then return end
+    if #(GetEntityCoords(ped) - GetEntityCoords(vehicle)) > 5.0 then return end
+    if GetPedInVehicleSeat(vehicle, -1) ~= 0 then return end
 
     Entity(vehicle).state:set('pushVehicle', data.direction, true)
 end)


### PR DESCRIPTION
## Summary
- make hunger and thirst compatibility events server-only
- whitelist consumables removed by the drug callback
- validate vehicle pushing and add tackle proximity/cooldown checks

## Security impact
Blocks arbitrary client metadata updates and limits remote entity/player manipulation to valid nearby interactions.

## Validation
- git diff --check
- FiveM Lua lint and CodeQL will run in CI